### PR TITLE
Remove incorrect help command and adding missing authorization ID. Closes #2.

### DIFF
--- a/src/scripts/ibmcloud-auth.js
+++ b/src/scripts/ibmcloud-auth.js
@@ -6,10 +6,6 @@
 //   HUBOT_IBMCLOUD_READERUSERS=<comma-separated list of reader-user emails -- no spaces!>
 //   HUBOT_IBMCLOUD_AUTHENTICATION_DISABLED=<only if desired, disables authentication and authorization if true)>
 //
-// Commands:
-//   hubot app(s) help - Show available commands in the app category.
-//
-//
 /*
 * Licensed Materials - Property of IBM
 * (C) Copyright IBM Corp. 2016. All Rights Reserved.
@@ -55,6 +51,7 @@ var READER_COMMANDS = [
 	'bluemix.space.service.list',
 	'bluemix.space.set',
 	'bluemix.vs.list',
+	'bluemix.app.problems',
 	'objectstorage.container.list',
 	'objectstorage.container.details',
 	'openwhisk.action.list',


### PR DESCRIPTION
https://github.com/ibm-cloud-solutions/hubot-ibmcloud-auth/issues/2
